### PR TITLE
DE-3409: Update to use newer publish action tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         # NOTE: update reference here to use a different version of the action
-        uses: tetrascience/ts-deploy-task-script-action@0.1.0
+        uses: tetrascience/ts-deploy-task-script-action@0.2.0
         with:
           namespace: ${{ inputs.namespace }}
           slug: ${{ inputs.slug }}


### PR DESCRIPTION
Update the artifact publish workflow to use the latest tag. 

---

NOTE: This cannot be merged until after https://github.com/tetrascience/ts-deploy-task-script-action/pull/3 is merged and tagged.