### PR TITLE
EP-153: Add coverage and upload to codacy if secret exists

### DIFF
--- a/.github/workflows/python_code_quality.yml
+++ b/.github/workflows/python_code_quality.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: boolean
         default: true
+    secrets:
+      CODACY_PROJECT_TOKEN:
+        required: false
+
 jobs:
   lint:
     name: Run python linters
@@ -82,23 +86,30 @@ jobs:
         run: |
           pip install pipenv
           pipenv sync --dev
-          pipenv run python -m pytest -v
+          pipenv run pip install pytest-cov
+          pipenv run python -m pytest -v --cov --cov-branch --cov-report xml
       # check for a poetry lockfile (since we can't rely on pyproject.toml indicating a poetry project)
       - name: Test with poetry
         if: hashFiles('poetry.lock') != ''
         run: |
           pip install poetry
           poetry install
-          poetry run python -m pytest -v
+          poetry run pip install pytest-cov
+          poetry run python -m pytest -v --cov --cov-branch --cov-report xml
       # no pipfile or poetry lockfile, so we'll just install pytest with pip and run that
       - name: Test with pip
         if: hashFiles('Pipfile') == '' && hashFiles('poetry.lock') == ''
         run: |
-          pip install pytest
-          python -m pytest -v
+          pip install pytest pytest-cov
+          python -m pytest -v --cov --cov-branch --cov-report xml
 
-      - uses: actions/upload-artifact@v3
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        # Only run if the CODACY_PROJECT_TOKEN is set
+        # Pattern from https://github.community/t/how-can-i-test-if-secrets-are-available-in-an-action/17911/10
+        env:
+          CODACY_CHECK: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        if: env.CODACY_CHECK
         with:
-          name: codecoverage
-          path: coverage.xml
-          if-no-files-found: ignore
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage.xml


### PR DESCRIPTION
## JIRA ticket

https://tetrascience.atlassian.net/browse/EP-153

## Description

This adds the option for repositories to upload their coverage reports to Codacy.  In order to make use of this function, each repo will need to add a secret named `CODACY_PROJECT_TOKEN` and pass that into the reusable workflow as a secret.  If the secret is not passed in, then the workflow will not even try to upload a report.

## Supporting test data

Here is a different PR that is using the reusable workflow from this PR https://github.com/tetrascience/ts-task-script-utils/pull/20

You can see in the "Checks" that the coverage report was uploaded.  You can also see in codacy that the report was received: https://app.codacy.com/gh/tetrascience/ts-task-script-utils/settings/coverage

Once this PR is merged, I will update the other one to point back at the `main` branch.

## Automated testing
<!-- What type of test automation is included as part of this PR to ensure that the change is working as expected? !-->
- [ ] Unit tests
- [ ] Integration tests
- [ ] API tests
- [ ] End-To-End tests
- [x] N/A (please clarify)

No automated tests for this process.