### PR TITLE
DE-3757: add lfs support to pytest checkout step only

### DIFF
--- a/.github/workflows/python_code_quality.yml
+++ b/.github/workflows/python_code_quality.yml
@@ -75,6 +75,8 @@ jobs:
     steps:
       # Checkout the code
       - uses: actions/checkout@v2
+        with:
+          lfs: true
       # Install a fixed version of python
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
## JIRA ticket
<!-- JIRA ticket !-->
https://tetrascience.atlassian.net/browse/DE-3757

## Description
<!-- Please describe what has been changed and why. Please add anything that can help the reviewer(s) to understand the context of the change !-->
pytest currently fails for [fcs-raw-to-ids PR #3 for DE-3491](https://github.com/tetrascience/ts-task-script-fcs-raw-to-ids/pull/3) because the pytest action isn't pulling in files from git lfs. The change here should resolve that issue.

## Supporting test data
<!-- This section could include screenshot, gifs or other supporting material that demonstrates the code works as expected !-->
Using [this PR](https://github.com/tetrascience/ts-task-script-fcs-raw-to-ids/pull/6) into `ts-task-script-fcs-raw-to-ids`, [the automated run of pytest successfully completed](https://github.com/tetrascience/ts-task-script-fcs-raw-to-ids/runs/6096440090?check_suite_focus=true)!  😃 

## Automated testing
<!-- What type of test automation is included as part of this PR to ensure that the change is working as expected? !-->
- [ ] Unit tests
- [ ] Integration tests
- [ ] API tests
- [ ] End-To-End tests
- [ ] N/A (please clarify)