### PR TITLE
DE-3675: Run pylint only in Codacy

### DIFF
--- a/.github/workflows/python_code_quality.yml
+++ b/.github/workflows/python_code_quality.yml
@@ -1,5 +1,4 @@
-# This workflow will add 3 jobs:
-# - lint: uses `flake8` to lint the code and add comments if it is a PR
+# This workflow will add 2 jobs:
 # - check-format: checks whether any files would be reformatted by `black`
 # - test: runs `pytest`.  Uses `pipenv`, `poetry`, or `pip` depending on the files present
 
@@ -21,20 +20,6 @@ on:
         required: false
 
 jobs:
-  codacy-analysis-cli:
-    name: Codacy Analysis CLI
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@main
-
-      - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@master
-        with:
-          tool: pylint
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          upload: true
-          max-allowed-issues: 2147483647
   check-format:
     name: Check formatting
     runs-on: ubuntu-latest

--- a/.github/workflows/python_code_quality.yml
+++ b/.github/workflows/python_code_quality.yml
@@ -21,38 +21,20 @@ on:
         required: false
 
 jobs:
-  lint:
-    name: Run python linters
+  codacy-analysis-cli:
+    name: Codacy Analysis CLI
     runs-on: ubuntu-latest
     steps:
-      # Checkout the code
-      - name: Checkout Code
-        uses: actions/checkout@v2
-      # Setup the reviewdog app
-      - uses: reviewdog/action-setup@v1
-        with:
-          reviewdog_version: latest # Optional. [latest,nightly,v.X.Y.Z]
-      # Install any linters we will use
-      - name: Install linters
-        run: |
-          pip install flake8 pylint
-      - name: Run linters
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "::group::*** FLAKE8 LINTING ***"
-          flake8 . | reviewdog -reporter="github-pr-review" -f flake8 -name flake8 -level info  -tee
-          echo "::endgroup::"
-          echo "::group::*** PYLINT LINTING ***"
-          # pylint is a little trickier to run.  This command:
-          # - finds all python files (output: './main.py', './src/parse.py')
-          # - prints only the files and directories that are in the current directory with awk (output: 'main.py', 'src')
-          # - removes duplicates with sort -u (unique)
-          find . -name '*py' | awk -F / '{print $2}' | sort -u > files_for_pylint.txt
-          # run these files/dirs through pylint and let reviewdog post comments
-          cat files_for_pylint.txt | xargs pylint | reviewdog -reporter="github-pr-review" -efm="%f:%l:%c: %m" -name pylint -level info --tee
-          echo "::endgroup::"
+      - name: Checkout code
+        uses: actions/checkout@main
 
+      - name: Run Codacy Analysis CLI
+        uses: codacy/codacy-analysis-cli-action@master
+        with:
+          tool: pylint
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          upload: true
+          max-allowed-issues: 2147483647
   check-format:
     name: Check formatting
     runs-on: ubuntu-latest


### PR DESCRIPTION
## JIRA ticket
https://tetrascience.atlassian.net/browse/DE-3675

## Description

As per our discussion this week, this ticket's changed to delete `pylint` and `flake8` from the common Github workflow. From now on we'll use only Codacy in CI.