### PR TITLE
DE-3707: pypi publish GitHub action POC

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -42,7 +42,7 @@ jobs:
           repo_name=`echo $GITHUB_REPOSITORY | awk -F "/" '{print $2}'`
           repo_file="$repo_name.txt"
           git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
-          wget $git_repo_owner_file -T 30
+          wget $git_repo_owner_file
           ls -l
           if [[ $? != 0 ]]; then
               echo "Failed to download $git_repo_owner_file"

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,7 +1,3 @@
-# This workflow will add 2 jobs:
-# - check-format: checks whether any files would be reformatted by `black`
-# - test: runs `pytest`.  Uses `pipenv`, `poetry`, or `pip` depending on the files present
-
 name: PyPI Publisher
 
 on:
@@ -30,10 +26,6 @@ jobs:
     steps:
       # Checkout the code
       - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ inputs.python-version }}
       - name: Validate github actor
         # Download the Owners file for ts-data-insights-code-owners
         # Proceed only if Owner file has been downloaded, make sure
@@ -72,9 +64,27 @@ jobs:
               exit 1
           fi
 
-      - name: Validate Package Manger
+      - name: Validate Github Release Version
+        # Ensure that github release version has a
+        # valid version format
+        run: |
+          github_release_version=$(echo $GITHUB_REF_NAME | tr -d 'v')
+          version_regex='^([0-9]+\.){0,2}(\*|[0-9]+)$'
+          if [[ $github_release_version =~ $version_regex ]]; then
+            echo "Release version '$github_release_version' is valid."
+          else
+            echo "Invalid release version: $github_release_version"
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Validate Package Manager
         # Stop GA if both setup.py and poetry.lock are present
-        # We dont know which one to use
+        # As we don't know which one to use
         run: |
           if [[ -f setup.py && -f poetry.lock ]]; then
             echo "Both setup.py and poetry.lock exists. Only one of them must be present."
@@ -84,32 +94,20 @@ jobs:
       - name: Build Package using Poetry
         if: hashFiles('poetry.lock') != ''
         run: |
-          echo "Building Package"
           python3 -m pip install --upgrade pip setuptools wheel
           python3 -m pip install poetry
           python3 -m poetry build
 
-          echo "\nValidating Build Version"
-          build_version=$(ls dist/*tar.gz | awk -F"-" '{ print $2 }' | awk -F".tar" '{ print $1 }')
-          github_release_version=$(echo $GITHUB_REF_NAME | tr -d 'v')
-          echo "Build Version: ${build_version}"
-          echo "Github Release version: ${github_release_version}"
-          if [[ "$build_version" != "$github_release_version" ]]; then
-            echo "Release Version mismatch. Stopping..."
-            exit 1
-          fi
-
       - name: Build Package using setup.py
         if: hashFiles('setup.py') != ''
         run: |
-          echo "$PWD"
-          ls -l $PWD
-          echo "\nBuilding Package"
           python3 -m pip install --upgrade pip setuptools wheel build
           python3 -m build
 
-
-          echo "\nValidating Build Version"
+      - name: Validate Build Version
+        # Ensure that version of the python package built in
+        # previous step is same as the github release version
+        run: |
           build_version=$(ls dist/*tar.gz | awk -F "-" '{ print $2 }' | awk -F ".tar" '{ print $1 }')
           github_release_version=$(echo $GITHUB_REF_NAME | tr -d 'v')
           echo "Build Version: ${build_version}"

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -33,20 +33,14 @@ jobs:
           echo "Checking if user '$GITHUB_ACTOR' is authorized to release the package."
           repo_name=`echo $GITHUB_REPOSITORY | awk -F "/" '{print $2}'`
           repo_file="$repo_name.txt"
-
           if [[ -f $repo_file ]]; then
             rm -rf $repo_file
           fi
           git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
           wget $git_repo_owner_file
-
-          matched_actor=`grep -x $GITHUB_ACTOR $repo_file`
-          if [[ $matched_actor != $GITHUB_ACTOR ]]; then
-              echo "Unauthorized user: $GITHUB_ACTOR"
-              echo "Only following users are authorized: "
-              echo `cat $repo_file`
-              exit 1
-          fi
+          echo "Only following users are authorized: "
+          cat $repo_file
+          grep -x $GITHUB_ACTOR $repo_file
           echo "User '$GITHUB_ACTOR' is authorized."
 
       - name: Validate Github Release Version

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ inputs.python-version }}
+      - name: printenv
+        run: printenv
+
       - name: Validate Package Manger
         # Stop GA if both setup.py and poetry.lock are present
         # We dont know which one to use

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -43,7 +43,12 @@ jobs:
           repo_file="$repo_name.txt"
           git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
           wget $git_repo_owner_file
-
+          return_code=$?
+          echo "$return_code"
+          if [[ return_code != 0 ]]; then
+              echo "Failed to download $git_repo_owner_file"
+              exit 1
+          fi
           if [[ $? != 0 ]]; then
               echo "Failed to download $git_repo_owner_file"
               exit 1

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -39,7 +39,7 @@ jobs:
         # Proceed only if Owner file has been downloaded, make sure
         # GITHUB_ACTOR is listed in the owner file
         run: |
-          repo_name=`echo $GITHUB_REPO | awk -F "/" '{print $2}'`
+          repo_name=`echo $GITHUB_REPOSITORY | awk -F "/" '{print $2}'`
           repo_file="$repo_name.txt"
           git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
           wget $git_repo_owner_file -T 5

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -49,14 +49,19 @@ jobs:
               echo "Failed to download $git_repo_owner_file"
               exit 1
           fi
-          if [[ $? != 0 ]]; then
-              echo "Failed to download $git_repo_owner_file"
-              exit 1
-          fi
-          grep_owner=`cat $repo_file | grep $GITHUB_ACTOR`
-          echo "$?"
-          echo "$grep_owner"
-          if [[ $grep_owner != $GITHUB_ACTOR ]]; then
+          authorized=false
+          while read line; do
+              if [[ $authorized == true ]]; then
+                  break
+              fi
+
+              if [[ $line == $GITHUB_ACTOR ]]; then
+                  echo "$line==$GITHUB_ACTOR"
+                  authorized=true
+              fi
+          done < $repo_file
+
+          if [[ $authorized == false ]]; then
               echo "Unauthorized user: $GITHUB_ACTOR"
               echo "Authorized Users:"
               echo `cat $repo_file`

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -45,7 +45,7 @@ jobs:
           wget $git_repo_owner_file
           return_code=$?
           echo "$return_code"
-          if [[ return_code != 0 ]]; then
+          if [[ $return_code != 0 ]]; then
               echo "Failed to download $git_repo_owner_file"
               exit 1
           fi

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -54,6 +54,8 @@ jobs:
               exit 1
           fi
           grep_owner=`cat $repo_file | grep $GITHUB_ACTOR`
+          echo "$?"
+          echo "$grep_owner"
           if [[ $grep_owner != $GITHUB_ACTOR ]]; then
               echo "Unauthorized user: $GITHUB_ACTOR"
               echo "Authorized Users:"

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,89 @@
+# This workflow will add 2 jobs:
+# - check-format: checks whether any files would be reformatted by `black`
+# - test: runs `pytest`.  Uses `pipenv`, `poetry`, or `pip` depending on the files present
+
+name: PyPI Publisher
+
+on:
+  workflow_call:
+    inputs:
+      # Python version is required in order to make sure that pytest and black can be run correctly
+      python-version:
+        required: true
+        type: string
+    secrets:
+      PYPI_TEST_TOKEN:
+        required: false
+      PYPI_PROD_TOKEN:
+        required: false
+      ARTIFACTORY_USER:
+        required: false
+      ARTIFACTORY_PASSWORD:
+        required: false
+      ARTIFACTORY_URL:
+        required: false
+
+jobs:
+  pypi-publish:
+    name: PyPI Publish
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the code
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Validate Package Manger
+        # Stop GA if both setup.py and poetry.lock are present
+        # We dont know which one to use
+        run: |
+          if [[ -f setup.py && -f poetry.lock ]]; then
+            echo "Both setup.py and poetry.lock exists. Only one of them must be present."
+            exit 1
+          fi
+
+      - name: Build Package using Poetry
+        if: hashFiles('poetry.lock') != ''
+        run: |
+          echo "Building Package"
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install poetry
+          python3 -m poetry build
+
+          echo "\nValidating Build Version"
+          build_version=$(ls dist/*tar.gz | awk -F"-" '{ print $2 }' | awk -F".tar" '{ print $1 }')
+          github_release_version=$(echo $GITHUB_REF_NAME | tr -d 'v')
+          echo "Build Version: ${build_version}"
+          echo "Github Release version: ${github_release_version}"
+          if [[ "$build_version" != "$github_release_version" ]]; then
+            echo "Release Version mismatch. Stopping..."
+            exit 1
+          fi
+
+      - name: Build Package using setup.py
+        if: hashFiles('setup.py') != ''
+        run: |
+          echo "$PWD"
+          ls -l $PWD
+          echo "\nBuilding Package"
+          python3 -m pip install --upgrade pip setuptools wheel build
+          python3 -m build
+
+
+          echo "\nValidating Build Version"
+          build_version=$(ls dist/*tar.gz | awk -F "-" '{ print $2 }' | awk -F ".tar" '{ print $1 }')
+          github_release_version=$(echo $GITHUB_REF_NAME | tr -d 'v')
+          echo "Build Version: ${build_version}"
+          echo "Github Release version: ${github_release_version}"
+          if [[ "$build_version" != "$github_release_version" ]]; then
+            echo "Release Version mismatch. Stopping..."
+            exit 1
+          fi
+
+      - name: Publish package to test pypi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TEST_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -42,7 +42,8 @@ jobs:
           repo_name=`echo $GITHUB_REPOSITORY | awk -F "/" '{print $2}'`
           repo_file="$repo_name.txt"
           git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
-          wget $git_repo_owner_file
+          ls -l
+          curl -O $git_repo_owner_file
           ls -l
           if [[ $? != 0 ]]; then
               echo "Failed to download $git_repo_owner_file"

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -42,21 +42,18 @@ jobs:
           repo_name=`echo $GITHUB_REPOSITORY | awk -F "/" '{print $2}'`
           repo_file="$repo_name.txt"
           git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
-          ls -l
-          curl -O $git_repo_owner_file
-          ls -l
+          wget $git_repo_owner_file
+
           if [[ $? != 0 ]]; then
               echo "Failed to download $git_repo_owner_file"
               exit 1
           fi
-          if [[ -f $repo_file ]]; then
-            grep_owner=`cat $repo_file | grep GITHUB_ACTOR`
-            if [[ $grep_owner != $GITHUB_ACTOR ]]; then
-              echo "Unauthorized user: $grep_owner"
+          grep_owner=`cat $repo_file | grep $GITHUB_ACTOR`
+          if [[ $grep_owner != $GITHUB_ACTOR ]]; then
+              echo "Unauthorized user: $GITHUB_ACTOR"
               echo "Authorized Users:"
               echo `cat $repo_file`
               exit 1
-            fi
           fi
 
       - name: Validate Package Manger

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           repo_name=`echo $GITHUB_REPOSITORY | awk -F "/" '{print $2}'`
           repo_file="$repo_name.txt"
+
+          if [[ -f $repo_file ]]; then
+            rm -rf $repo_file
+          fi
           git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
           wget $git_repo_owner_file
           return_code=$?

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -43,9 +43,11 @@ jobs:
               echo "Failed to download $git_repo_owner_file"
               exit 1
           fi
-          grep -x $GITHUB_ACTOR $repo_file
-          if [[ $? != 0 ]]; then
-              echo "User '$GITHUB_ACTOR' is not authorized."
+          matched_actor=`grep -x $GITHUB_ACTOR $repo_file`
+          if [[ $matched_actor != $GITHUB_ACTOR ]]; then
+              echo "Unauthorized user: $GITHUB_ACTOR"
+              echo "Only following users are authorized: "
+              echo `cat $repo_file`
               exit 1
           fi
           echo "User '$GITHUB_ACTOR' is authorized."

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -30,7 +30,7 @@ jobs:
         # Proceed only if Owner file has been downloaded, make sure
         # GITHUB_ACTOR is listed in the owner file
         run: |
-          echo "Checking if user `$GITHUB_ACTOR` is authorized to release the package."
+          echo "Checking if user '$GITHUB_ACTOR' is authorized to release the package."
           repo_name=`echo $GITHUB_REPOSITORY | awk -F "/" '{print $2}'`
           repo_file="$repo_name.txt"
 
@@ -44,7 +44,11 @@ jobs:
               exit 1
           fi
           grep -x $GITHUB_ACTOR $repo_file
-          echo "User `$GITHUB_ACTOR` is authorized."
+          if [[ $? != 0 ]]; then
+              echo "User '$GITHUB_ACTOR' is not authorized."
+              exit 1
+          fi
+          echo "User '$GITHUB_ACTOR' is authorized."
 
       - name: Validate Github Release Version
         # Ensure that github release version has a

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -39,10 +39,7 @@ jobs:
           fi
           git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
           wget $git_repo_owner_file
-          if [[ $? != 0 ]]; then
-              echo "Failed to download $git_repo_owner_file"
-              exit 1
-          fi
+
           matched_actor=`grep -x $GITHUB_ACTOR $repo_file`
           if [[ $matched_actor != $GITHUB_ACTOR ]]; then
               echo "Unauthorized user: $GITHUB_ACTOR"

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
     inputs:
       python-version:
+        #python version is required in order to make sure that the package can be built
         required: true
         type: string
     secrets:

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -42,7 +42,8 @@ jobs:
           repo_name=`echo $GITHUB_REPOSITORY | awk -F "/" '{print $2}'`
           repo_file="$repo_name.txt"
           git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
-          wget $git_repo_owner_file -T 5
+          wget $git_repo_owner_file -T 30
+          ls -l
           if [[ $? != 0 ]]; then
               echo "Failed to download $git_repo_owner_file"
               exit 1

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -34,8 +34,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ inputs.python-version }}
-      - name: printenv
-        run: printenv
 
       - name: Validate Package Manger
         # Stop GA if both setup.py and poetry.lock are present

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -3,7 +3,6 @@ name: PyPI Publisher
 on:
   workflow_call:
     inputs:
-      # Python version is required in order to make sure that pytest and black can be run correctly
       python-version:
         required: true
         type: string
@@ -31,6 +30,7 @@ jobs:
         # Proceed only if Owner file has been downloaded, make sure
         # GITHUB_ACTOR is listed in the owner file
         run: |
+          echo "Checking if user `$GITHUB_ACTOR` is authorized to release the package."
           repo_name=`echo $GITHUB_REPOSITORY | awk -F "/" '{print $2}'`
           repo_file="$repo_name.txt"
 
@@ -39,30 +39,12 @@ jobs:
           fi
           git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
           wget $git_repo_owner_file
-          return_code=$?
-          echo "$return_code"
-          if [[ $return_code != 0 ]]; then
+          if [[ $? != 0 ]]; then
               echo "Failed to download $git_repo_owner_file"
               exit 1
           fi
-          authorized=false
-          while read line; do
-              if [[ $authorized == true ]]; then
-                  break
-              fi
-
-              if [[ $line == $GITHUB_ACTOR ]]; then
-                  echo "$line==$GITHUB_ACTOR"
-                  authorized=true
-              fi
-          done < $repo_file
-
-          if [[ $authorized == false ]]; then
-              echo "Unauthorized user: $GITHUB_ACTOR"
-              echo "Authorized Users:"
-              echo `cat $repo_file`
-              exit 1
-          fi
+          grep -x $GITHUB_ACTOR $repo_file
+          echo "User `$GITHUB_ACTOR` is authorized."
 
       - name: Validate Github Release Version
         # Ensure that github release version has a

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -34,6 +34,28 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ inputs.python-version }}
+      - name: Validate github actor
+        # Download the Owners file for ts-data-insights-code-owners
+        # Proceed only if Owner file has been downloaded, make sure
+        # GITHUB_ACTOR is listed in the owner file
+        run: |
+          repo_name=`echo $GITHUB_REPO | awk -F "/" '{print $2}'`
+          repo_file="$repo_name.txt"
+          git_repo_owner_file="https://raw.githubusercontent.com/tetrascience/ts-data-insights-code-owners/main/$repo_file"
+          wget $git_repo_owner_file -T 5
+          if [[ $? != 0 ]]; then
+              echo "Failed to download $git_repo_owner_file"
+              exit 1
+          fi
+          if [[ -f $repo_file ]]; then
+            grep_owner=`cat $repo_file | grep GITHUB_ACTOR`
+            if [[ $grep_owner != $GITHUB_ACTOR ]]; then
+              echo "Unauthorized user: $grep_owner"
+              echo "Authorized Users:"
+              echo `cat $repo_file`
+              exit 1
+            fi
+          fi
 
       - name: Validate Package Manger
         # Stop GA if both setup.py and poetry.lock are present


### PR DESCRIPTION
## JIRA ticket
https://tetrascience.atlassian.net/browse/DE-3707


## Description
Making this PR a draft PR as it is a POC

- Check if release is triggered by authorised user
- Check if build version matches release version
- Build and publish using poetry if Poetry.lock is present
- Else use setup.py to build
- fail is both setup.py and poetry.lock are present

## Supporting test data
<!-- This section could include screenshot, gifs or other supporting material that demonstrates the code works as expected !-->

## Automated testing
<!-- What type of test automation is included as part of this PR to ensure that the change is working as expected? !-->
- [ ] Unit tests
- [ ] Integration tests
- [ ] API tests
- [x] End-To-End tests
- [ ] N/A (please clarify)


Invalid Version: https://github.com/tetrascience/ts-pypi-integ-test/runs/6587439287?check_suite_focus=true

Publish with setup.py: https://github.com/tetrascience/ts-pypi-integ-test/runs/6587476238?check_suite_focus=true
Publish with poetry: https://github.com/tetrascience/ts-pypi-integ-test/runs/6587541431?check_suite_focus=true

Unauthorized Github actor: https://github.com/tetrascience/ts-pypi-integ-test/runs/6587932120?check_suite_focus=true