### PR TITLE
DE-3965: Update ts-deploy-task-script-action version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         # NOTE: update reference here to use a different version of the action
-        uses: tetrascience/ts-deploy-task-script-action@v0.3.4
+        uses: tetrascience/ts-deploy-task-script-action@v0.3.5
         with:
           namespace: ${{ inputs.namespace }}
           slug: ${{ inputs.slug }}


### PR DESCRIPTION
Bamp the version of `ts-deploy-task-script-action` used so it's compatible with Windows Task Scripts.