### PR TITLE
FIX: Allow codacy upload to fail without failing the job

### DIFF
--- a/.github/workflows/python_code_quality.yml
+++ b/.github/workflows/python_code_quality.yml
@@ -94,6 +94,7 @@ jobs:
           python -m pytest -v --cov --cov-branch --cov-report xml
 
       - name: Run codacy-coverage-reporter
+        continue-on-error: true
         uses: codacy/codacy-coverage-reporter-action@v1
         # Only run if the CODACY_PROJECT_TOKEN is set
         # Pattern from https://github.community/t/how-can-i-test-if-secrets-are-available-in-an-action/17911/10


### PR DESCRIPTION
## JIRA ticket

<!-- JIRA ticket !-->
[No ticket](https://www.youtube.com/watch?v=iHSPf6x1Fdo)

## Description

<!-- Please describe what has been changed and why. Please add anything that can help the reviewer(s) to understand the context of the change !-->

Codacy's upload job has been failing, which means PRs cannot be merged.  This should not block our code, even if the coverage is not uploaded.

For a failure example, see: https://github.com/tetrascience/ts-task-script-thermofisher-viia7-eds-raw-to-ids/runs/6880724088?check_suite_focus=true

## Supporting test data

<!-- This section could include screenshot, gifs or other supporting material that demonstrates the code works as expected !-->

## Automated testing

<!-- What type of test automation is included as part of this PR to ensure that the change is working as expected? !-->

- [ ] Unit tests
- [ ] Integration tests
- [ ] API tests
- [ ] End-To-End tests
- [x] N/A (please clarify)
