### PR TITLE
FIX: Update publish action to not require "type" as an input

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       type:
-        required: true
+        required: false
         type: string
         # For backwards compatibility
         default: "task-script"


### PR DESCRIPTION
## JIRA ticket

<!-- JIRA ticket !-->
Discovered as part of https://tetrascience.atlassian.net/browse/DE-3681

## Description

<!-- Please describe what has been changed and why. Please add anything that can help the reviewer(s) to understand the context of the change !-->

I thought that `required: true` and `default: XYZ` would work together.
It turns out that is not the case, so I removed `required: true`


## Supporting test data

<!-- This section could include screenshot, gifs or other supporting material that demonstrates the code works as expected !-->

@nilsguillermin tested this branch here: https://github.com/tetrascience/ts-client-diagnostic-task-script-dei-regression/actions/runs/2584974361

## Automated testing

<!-- What type of test automation is included as part of this PR to ensure that the change is working as expected? !-->

- [ ] Unit tests
- [ ] Integration tests
- [ ] API tests
- [ ] End-To-End tests
- [ ] N/A (please clarify)
